### PR TITLE
fix(frontend): normalize Stampd ABI for starknet.js compatibility

### DIFF
--- a/frontend/src/abi/stampd.ts
+++ b/frontend/src/abi/stampd.ts
@@ -1,61 +1,50 @@
 export const STAMPD_ABI = [
   {
-    "type": "struct",
-    "name": "Receipt",
-    "members": [
-      { "name": "commitment", "type": "felt252" },
-      { "name": "freelancer", "type": "ContractAddress" },
-      { "name": "client", "type": "ContractAddress" },
-      { "name": "project_tag", "type": "felt252" },
-      { "name": "timestamp", "type": "u64" },
-      { "name": "status", "type": "felt252" }
-    ]
-  },
-
-  {
     "type": "function",
     "name": "stamp",
     "inputs": [
-      { "name": "commitment", "type": "felt252" },
-      { "name": "client", "type": "ContractAddress" },
-      { "name": "project_tag", "type": "felt252" }
+      { "name": "commitment", "type": "felt" },
+      { "name": "client", "type": "felt" },
+      { "name": "project_tag", "type": "felt" }
     ],
     "outputs": [
-      { "name": "receipt_id", "type": "u64" }
-    ],
-    "state_mutability": "external"
+      { "name": "receipt_id", "type": "felt" }
+    ]
   },
 
   {
     "type": "function",
     "name": "dispute",
     "inputs": [
-      { "name": "receipt_id", "type": "u64" }
+      { "name": "receipt_id", "type": "felt" }
     ],
-    "outputs": [],
-    "state_mutability": "external"
+    "outputs": []
   },
 
   {
     "type": "function",
     "name": "reveal",
     "inputs": [
-      { "name": "receipt_id", "type": "u64" },
-      { "name": "delivery_hash", "type": "felt252" },
-      { "name": "salt", "type": "felt252" }
+      { "name": "receipt_id", "type": "felt" },
+      { "name": "delivery_hash", "type": "felt" },
+      { "name": "salt", "type": "felt" }
     ],
-    "outputs": [],
-    "state_mutability": "external"
+    "outputs": []
   },
 
   {
     "type": "function",
     "name": "get_receipt",
     "inputs": [
-      { "name": "receipt_id", "type": "u64" }
+      { "name": "receipt_id", "type": "felt" }
     ],
     "outputs": [
-      { "type": "Receipt" }
+      { "name": "commitment", "type": "felt" },
+      { "name": "freelancer", "type": "felt" },
+      { "name": "client", "type": "felt" },
+      { "name": "project_tag", "type": "felt" },
+      { "name": "timestamp", "type": "felt" },
+      { "name": "status", "type": "felt" }
     ],
     "state_mutability": "view"
   }


### PR DESCRIPTION
This PR fixes the ABI definition used by the frontend to interact with the deployed Stampd contract on Starknet Sepolia.

Problem
The previous ABI definition used types that starknet.js could not correctly parse (ContractAddress, u64), which caused validation errors when invoking contract functions.

Changes
✔ normalized ABI types to starknet.js compatible types (felt)
✔ simplified get_receipt output structure
✔ updated frontend ABI file (frontend/src/abi/stampd.ts)

Result
✔ wallet signing works
✔ stamp() transactions execute successfully
✔ frontend → wallet → contract pipeline confirmed

Example Transaction
https://sepolia.voyager.online/tx/0x4e778b42c5ef21166d16314f8a06d526ff0182ecf6b8caf4586608ed8c20e83